### PR TITLE
Fix union bug

### DIFF
--- a/types/grid/geometa_grid/schema.py
+++ b/types/grid/geometa_grid/schema.py
@@ -88,8 +88,8 @@ def handler(path):
                                                 i['nativeBounds']['top'])
                             for i in metadata['subDatasets']]
         union = cascaded_union(subDatasetBounds)
-        bounds = {'left': union.bounds[0], 'right': union.bounds[1],
-                  'bottom': union.bounds[2], 'top': union.bounds[3]}
+        bounds = {'left': union.bounds[0], 'right': union.bounds[2],
+                  'bottom': union.bounds[1], 'top': union.bounds[3]}
         metadata['crs'] = crs
         metadata['type_'] = 'grid'
         metadata['driver'] = dataset.GetDriver().LongName

--- a/types/grid/geometa_grid/schema.py
+++ b/types/grid/geometa_grid/schema.py
@@ -4,7 +4,7 @@ from geometa import from_bounds_to_geojson, CannotHandleError
 import gdal
 import osr
 from shapely.geometry import Polygon
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 
 class SubDatasets(fields.Field):
@@ -87,7 +87,7 @@ def handler(path):
                                                 i['nativeBounds']['right'],
                                                 i['nativeBounds']['top'])
                             for i in metadata['subDatasets']]
-        union = cascaded_union(subDatasetBounds)
+        union = unary_union(subDatasetBounds)
         bounds = {'left': union.bounds[0], 'right': union.bounds[2],
                   'bottom': union.bounds[1], 'top': union.bounds[3]}
         metadata['crs'] = crs

--- a/types/grid/tests/test_grid_schema.py
+++ b/types/grid/tests/test_grid_schema.py
@@ -40,7 +40,7 @@ def test_union_subdataset_bounds(server, admin, fsAssetstore):
 
     with open(testFile, 'rb') as f:
         uploadedFile = server.uploadFile(name, f.read(), admin, public.json[0])
-        document = File().load(uploadedFile['_id'], user=admin)
+        document = Item().load(uploadedFile['itemId'], user=admin)
 
     if document['geometa']['subDatasets'] == 1:
         assert document['geometa']['bounds'] == document['geometa']['subDatasetInfo'][0]['bounds']

--- a/types/grid/tests/test_grid_schema.py
+++ b/types/grid/tests/test_grid_schema.py
@@ -25,3 +25,22 @@ def test_grid_geometa(server, admin, fsAssetstore, testFile, expected):
         expectedJson = json.load(f)
 
     assert list(document['geometa']).sort() == list(expectedJson).sort()
+
+
+@pytest.mark.plugin('geometa')
+def test_union_subdataset_bounds(server, admin, fsAssetstore):
+    testFile = 'tests/data/sresa1b_ncar_ccsm3-example.nc'
+    name = os.path.basename(testFile)
+
+    public = server.request(path='/folder', user=admin, method='GET',
+                            params={'parentId': admin['_id'],
+                                    'parentType': 'user',
+                                    'name': 'Public'})
+    assertStatusOk(public)
+
+    with open(testFile, 'rb') as f:
+        uploadedFile = server.uploadFile(name, f.read(), admin, public.json[0])
+        document = File().load(uploadedFile['_id'], user=admin)
+
+    if document['geometa']['subDatasets'] == 1:
+        assert document['geometa']['bounds'] == document['geometa']['subDatasetInfo'][0]['bounds']

--- a/types/vector/geometa_vector/schema.py
+++ b/types/vector/geometa_vector/schema.py
@@ -3,7 +3,7 @@ from geometa.schema import BaseSchema
 from geometa import from_bounds_to_geojson, CannotHandleError
 import ogr
 from shapely.geometry import Polygon
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 
 class Layers(fields.Field):
@@ -71,7 +71,7 @@ def handler(path):
                                            i['nativeBounds']['right'],
                                            i['nativeBounds']['top'])
                        for i in metadata['layerInfo']]
-        union = cascaded_union(layerBounds)
+        union = unary_union(layerBounds)
         layer = dataset.GetLayer(0)
         crs = layer.GetSpatialRef().ExportToProj4()
         bounds = {'left': union.bounds[0], 'right': union.bounds[2],

--- a/types/vector/geometa_vector/schema.py
+++ b/types/vector/geometa_vector/schema.py
@@ -74,8 +74,8 @@ def handler(path):
         union = cascaded_union(layerBounds)
         layer = dataset.GetLayer(0)
         crs = layer.GetSpatialRef().ExportToProj4()
-        bounds = {'left': union.bounds[0], 'right': union.bounds[1],
-                  'bottom': union.bounds[2], 'top': union.bounds[3]}
+        bounds = {'left': union.bounds[0], 'right': union.bounds[2],
+                  'bottom': union.bounds[1], 'top': union.bounds[3]}
         metadata['crs'] = crs
         metadata['nativeBounds'] = bounds
         metadata['type_'] = 'vector'

--- a/types/vector/tests/test_vector_schema.py
+++ b/types/vector/tests/test_vector_schema.py
@@ -41,7 +41,7 @@ def test_union_layer_bounds(server, admin, fsAssetstore):
 
     with open(testFile, 'rb') as f:
         uploadedFile = server.uploadFile(name, f.read(), admin, public.json[0])
-        document = File().load(uploadedFile['_id'], user=admin)
+        document = Item().load(uploadedFile['itemId'], user=admin)
 
     if document['geometa']['layers'] == 1:
         assert document['geometa']['bounds'] == document['geometa']['layerInfo'][0]['bounds']

--- a/types/vector/tests/test_vector_schema.py
+++ b/types/vector/tests/test_vector_schema.py
@@ -26,3 +26,22 @@ def test_vector_geometa(server, admin, fsAssetstore, testFile, expected):
         expectedJson = json.load(f)
 
     assert list(document['geometa']).sort() == list(expectedJson).sort()
+
+
+@pytest.mark.plugin('geometa')
+def test_union_layer_bounds(server, admin, fsAssetstore):
+    testFile = 'tests/data/stations.geojson'
+    name = os.path.basename(testFile)
+
+    public = server.request(path='/folder', user=admin, method='GET',
+                            params={'parentId': admin['_id'],
+                                    'parentType': 'user',
+                                    'name': 'Public'})
+    assertStatusOk(public)
+
+    with open(testFile, 'rb') as f:
+        uploadedFile = server.uploadFile(name, f.read(), admin, public.json[0])
+        document = File().load(uploadedFile['_id'], user=admin)
+
+    if document['geometa']['layers'] == 1:
+        assert document['geometa']['bounds'] == document['geometa']['layerInfo'][0]['bounds']


### PR DESCRIPTION
Fixes #10. Fixes a bug associated with unioning geometries if there are multiple layers in a vector or multiple subdatasets in a grid file. Ignore circleci for now.