### PR TITLE
Listen to file.save.after event

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,20 +1,18 @@
 from girder import events
-from girder.models.file import File
 from girder.models.item import Item
 from .rest import (geometa_search_handler, geometa_create_handler,
                    geometa_get_handler, create_geometa)
 
 
-def file_upload_handler(event):
-    _id = event.info['file']['_id']
-    girder_file = File().load(_id, force=True)
-    girder_item = Item().load(event.info['file']['itemId'], force=True)
+def handler(event):
+    girder_item = Item().load(event.info['itemId'], force=True)
+    girder_file = list(Item().childFiles(girder_item, limit=1, force=True))[0]
     create_geometa(girder_item, girder_file)
 
 
 def load(info):
-    events.bind('model.file.finalizeUpload.after',
-                info['name'], file_upload_handler)
+    events.bind('model.file.save.after',
+                info['name'], handler)
     info['apiRoot'].item.route('GET', ('geometa',),
                                geometa_search_handler)
     info['apiRoot'].item.route('GET', (':id', 'geometa'),


### PR DESCRIPTION
Listens to an event which is more suitable for different use cases such as 
assetstore imports which does not trigger the upload events.

Almost all operations that deals with ingesting data to girder triggers model.file.save.after
event. Which makes it much more applicable to different use cases. 