### PR TITLE
Do not break when uploading files without an item

### DIFF
--- a/geometa/__init__.py
+++ b/geometa/__init__.py
@@ -13,6 +13,7 @@ def file_upload_handler(event):
     create_geometa(girder_item, girder_file)
     events.trigger('geometa.created', info=event.info)
 
+
 class GeometaPlugin(GirderPlugin):
     DISPLAY_NAME = 'Geometa Plugin'
 

--- a/geometa/__init__.py
+++ b/geometa/__init__.py
@@ -1,5 +1,4 @@
 from girder import events
-from girder.models.file import File
 from girder.models.item import Item
 from girder.plugin import GirderPlugin
 from .rest import (geometa_search_handler, geometa_create_handler,
@@ -7,10 +6,10 @@ from .rest import (geometa_search_handler, geometa_create_handler,
 
 
 def file_upload_handler(event):
-    _id = event.info['file']['_id']
-    girder_file = File().load(_id, force=True)
-    girder_item = Item().load(event.info['file']['itemId'], force=True)
-    create_geometa(girder_item, girder_file)
+    file = event.info['file']
+    if file.get('itemId'):
+        girder_item = Item().load(file['itemId'], force=True)
+        create_geometa(girder_item, file)
 
 
 class GeometaPlugin(GirderPlugin):

--- a/geometa/__init__.py
+++ b/geometa/__init__.py
@@ -1,5 +1,4 @@
 from girder import events
-from girder.models.file import File
 from girder.models.item import Item
 from girder.plugin import GirderPlugin
 from .rest import (geometa_search_handler, geometa_create_handler,
@@ -7,11 +6,11 @@ from .rest import (geometa_search_handler, geometa_create_handler,
 
 
 def file_upload_handler(event):
-    _id = event.info['file']['_id']
-    girder_file = File().load(_id, force=True)
-    girder_item = Item().load(event.info['file']['itemId'], force=True)
-    create_geometa(girder_item, girder_file)
-    events.trigger('geometa.created', info=event.info)
+    file = event.info['file']
+    if file.get('itemId'):
+        girder_item = Item().load(file['itemId'], force=True)
+        create_geometa(girder_item, file)
+        events.trigger('geometa.created', info=event.info)
 
 
 class GeometaPlugin(GirderPlugin):

--- a/geometa/__init__.py
+++ b/geometa/__init__.py
@@ -11,7 +11,7 @@ def file_upload_handler(event):
     girder_file = File().load(_id, force=True)
     girder_item = Item().load(event.info['file']['itemId'], force=True)
     create_geometa(girder_item, girder_file)
-
+    events.trigger('geometa.created', info=event.info)
 
 class GeometaPlugin(GirderPlugin):
     DISPLAY_NAME = 'Geometa Plugin'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme:
 
 setup(
     name='girder-geospatial',
-    version='0.1.0',
+    version='0.2.0',
     description='Generate metadata for various geospatial datasets',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps =
 
 install_command = pip install -f https://manthey.github.io/large_image_wheels {opts} {packages}
 commands =
-    py.test --cov-config .coveragerc --cov=geometa --cov=types -n auto
-	codecov
+    py.test --cov-config .coveragerc --cov=geometa --cov=types
+	  codecov
 
 [testenv:release]
 deps = twine


### PR DESCRIPTION
Girder supports files being created that do not have a parent item, such as thumbnails and some other special cases. I discovered this bug when geometa was running alongside a different Girder plugin that uses this feature. Now, geometa will only perform extraction on a file if it is a normal file with a parent item.
