### PR TITLE
Support different assetstores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ ci-steps: &ci-steps
     - run:
         name: Install mongodb
         command: |
-          apt-get update && apt-get install mongodb -y
+          apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+          echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | tee /etc/apt/sources.list.d/mongodb.list
+          apt update && apt install mongodb-org -y
           mkdir -p /data/db
 
     - run:
@@ -47,6 +49,13 @@ jobs:
      - TEST_TOX_ENV: "py36"
     <<: *ci-steps
 
+  python37:
+    docker:
+      - image: python:3.7
+    environment:
+     - TEST_TOX_ENV: "py37"
+    <<: *ci-steps
+
   linting:
     docker:
       - image: dozturk2/girder_geospatial
@@ -61,4 +70,5 @@ workflows:
       - python27
       - python35
       - python36
+      - python37
       - linting

--- a/geometa/rest.py
+++ b/geometa/rest.py
@@ -4,12 +4,10 @@ import inspect
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, describeRoute, Description
 from girder.api.rest import boundHandler, filtermodel
-from girder.exceptions import ValidationException
+from girder.exceptions import ValidationException, FilePathException
 from girder.models.item import Item
 from girder.models.file import File
-from girder.models.assetstore import Assetstore
 from girder.constants import AccessType
-from girder.utility import assetstore_utilities
 from girder.utility._cache import cache
 from geometa.schema import OpenSearchGeoSchema, BaseSchema
 from .constants import GEOSPATIAL_FIELD, GEOSPATIAL_SUBDATASETS_FIELD
@@ -60,12 +58,6 @@ def get_documents_by_radius(user, latitude, longitude, radius):
     return _find(user, query)
 
 
-def _get_path_from_filesystem(girder_file):
-    assetstore = Assetstore().load(girder_file['assetstoreId'])
-    adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-    return adapter.fullPath(girder_file)
-
-
 def _get_path_after_download(girder_file):
     with NamedTemporaryFile(delete=False) as f:
         path = f.name
@@ -77,8 +69,8 @@ def _get_path_after_download(girder_file):
 
 def _get_girder_path(girder_file):
     try:
-        path = _get_path_from_filesystem(girder_file)
-    except AttributeError:
+        path = File().getLocalFilePath(girder_file)
+    except FilePathException:
         path = _get_path_after_download(girder_file)
 
     return path

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,35,36}
+	py{27,35,36,37}
 	lint
 
 [testenv]


### PR DESCRIPTION
Fixes #34. 

This PR adds support for non filesystem assetstores. I tested it with an s3 assetstore and it worked.
It will try to find the local path for a file and if it fails it will download it to a temporary location and 
create geospatial metadata for the given item. 